### PR TITLE
Fix flake8 errors

### DIFF
--- a/OIPA/iati_synchroniser/dataset_syncer.py
+++ b/OIPA/iati_synchroniser/dataset_syncer.py
@@ -13,7 +13,7 @@ from iati_synchroniser.create_publisher_organisation import (
     create_publisher_organisation
 )
 from iati_synchroniser.models import Dataset, Publisher
-from task_queue.tasks import DatasetDownloadTask, DatasetValidationTask
+from task_queue.tasks import DatasetDownloadTask  #, DatasetValidationTask
 
 DATASET_URL = 'https://iatiregistry.org/api/action/package_search?rows=200&{options}'  # NOQA: E501
 PUBLISHER_URL = 'https://iatiregistry.org/api/action/organization_list?all_fields=true&include_extras=true&limit=50&{options}'  # NOQA: E501

--- a/OIPA/iati_synchroniser/dataset_syncer.py
+++ b/OIPA/iati_synchroniser/dataset_syncer.py
@@ -13,7 +13,7 @@ from iati_synchroniser.create_publisher_organisation import (
     create_publisher_organisation
 )
 from iati_synchroniser.models import Dataset, Publisher
-from task_queue.tasks import DatasetDownloadTask  #, DatasetValidationTask
+from task_queue.tasks import DatasetDownloadTask
 
 DATASET_URL = 'https://iatiregistry.org/api/action/package_search?rows=200&{options}'  # NOQA: E501
 PUBLISHER_URL = 'https://iatiregistry.org/api/action/organization_list?all_fields=true&include_extras=true&limit=50&{options}'  # NOQA: E501

--- a/OIPA/solr/signals.py
+++ b/OIPA/solr/signals.py
@@ -1,7 +1,7 @@
 from django.db.models import signals
 from django.dispatch import receiver
-from geodata.models import Country, Region
 
+from geodata.models import Country, Region
 from iati.models import Activity, Budget
 from iati.transaction.models import Transaction
 from iati_organisation.models import Organisation

--- a/OIPA/solr/signals.py
+++ b/OIPA/solr/signals.py
@@ -1,11 +1,11 @@
 from django.db.models import signals
 from django.dispatch import receiver
-
 from geodata.models import Country, Region
+
 from iati.models import Activity, Budget
 from iati.transaction.models import Transaction
 from iati_organisation.models import Organisation
-from iati_synchroniser.models import Publisher  #, Dataset
+from iati_synchroniser.models import Publisher
 from solr.activity.tasks import ActivityTaskIndexing
 from solr.budget.tasks import BudgetTaskIndexing
 from solr.codelists.country.tasks import CodeListCountryTaskIndexing
@@ -13,6 +13,7 @@ from solr.codelists.region.tasks import CodeListRegionTaskIndexing
 from solr.organisation.tasks import OrganisationTaskIndexing
 from solr.publisher.tasks import PublisherTaskIndexing
 from solr.transaction.tasks import TransactionTaskIndexing
+
 # @receiver(signals.post_save, sender=Dataset)
 # def dataset_post_save(sender, instance, **kwargs):
 #     DatasetTaskIndexing(instance=instance).run()

--- a/OIPA/solr/signals.py
+++ b/OIPA/solr/signals.py
@@ -10,12 +10,9 @@ from solr.activity.tasks import ActivityTaskIndexing
 from solr.budget.tasks import BudgetTaskIndexing
 from solr.codelists.country.tasks import CodeListCountryTaskIndexing
 from solr.codelists.region.tasks import CodeListRegionTaskIndexing
-# from solr.dataset.tasks import DatasetTaskIndexing
 from solr.organisation.tasks import OrganisationTaskIndexing
 from solr.publisher.tasks import PublisherTaskIndexing
 from solr.transaction.tasks import TransactionTaskIndexing
-#
-#
 # @receiver(signals.post_save, sender=Dataset)
 # def dataset_post_save(sender, instance, **kwargs):
 #     DatasetTaskIndexing(instance=instance).run()

--- a/OIPA/solr/signals.py
+++ b/OIPA/solr/signals.py
@@ -5,17 +5,17 @@ from geodata.models import Country, Region
 from iati.models import Activity, Budget
 from iati.transaction.models import Transaction
 from iati_organisation.models import Organisation
-from iati_synchroniser.models import Dataset, Publisher
+from iati_synchroniser.models import Publisher  #, Dataset
 from solr.activity.tasks import ActivityTaskIndexing
 from solr.budget.tasks import BudgetTaskIndexing
 from solr.codelists.country.tasks import CodeListCountryTaskIndexing
 from solr.codelists.region.tasks import CodeListRegionTaskIndexing
-from solr.dataset.tasks import DatasetTaskIndexing
+# from solr.dataset.tasks import DatasetTaskIndexing
 from solr.organisation.tasks import OrganisationTaskIndexing
 from solr.publisher.tasks import PublisherTaskIndexing
 from solr.transaction.tasks import TransactionTaskIndexing
-
-
+#
+#
 # @receiver(signals.post_save, sender=Dataset)
 # def dataset_post_save(sender, instance, **kwargs):
 #     DatasetTaskIndexing(instance=instance).run()

--- a/OIPA/task_queue/download.py
+++ b/OIPA/task_queue/download.py
@@ -4,7 +4,6 @@ import logging
 import os
 
 import celery
-# import requests
 from django.conf import settings
 
 from iati_synchroniser.models import Dataset, filetype_choices

--- a/OIPA/task_queue/download.py
+++ b/OIPA/task_queue/download.py
@@ -4,7 +4,7 @@ import logging
 import os
 
 import celery
-import requests
+# import requests
 from django.conf import settings
 
 from iati_synchroniser.models import Dataset, filetype_choices
@@ -139,8 +139,10 @@ class DatasetDownloadTask(celery.Task):
                 full_download_dir,
                 filename
             )
-            # headers = {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X '
-            #                          '10_11_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.102 Safari/537.36'}  # NOQA: E501
+            # headers = {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS '
+            #                           'X 10_11_5) AppleWebKit/537.36 (KHTML'
+            #                           ', like Gecko) Chrome/50.0.2661.102 '
+            #                           'Safari/537.36'}  # NOQA: E501
             #
             # try:
             #     with open(download_dir_with_filename, 'wb') as f:
@@ -154,7 +156,8 @@ class DatasetDownloadTask(celery.Task):
             #
             # except requests.exceptions.Timeout:
             #     with open(download_dir_with_filename, 'wb') as f:
-            #         resp = requests.get(dataset_url, verify=False, timeout=30)
+            #         resp = requests.get(dataset_url, verify=False,
+            #                    timeout=30)
             #         f.write(resp.content)
             # except (
             #      requests.exceptions.RequestException,

--- a/OIPA/task_queue/tasks.py
+++ b/OIPA/task_queue/tasks.py
@@ -1,6 +1,6 @@
 import datetime
 import hashlib
-import json
+# import json
 import logging
 import os
 import time

--- a/OIPA/task_queue/tasks.py
+++ b/OIPA/task_queue/tasks.py
@@ -1,6 +1,5 @@
 import datetime
 import hashlib
-# import json
 import logging
 import os
 import time


### PR DESCRIPTION
I was seeing the following errors pop up in circleCI's pep8 code style checks, which were breaking the validation of my new branches off of develop.
`OIPA/solr/signals.py:8:1: F401 'iati_synchroniser.models.Dataset' imported but unused
OIPA/solr/signals.py:13:1: F401 'solr.dataset.tasks.DatasetTaskIndexing' imported but unused
OIPA/solr/signals.py:17:1: I004 isort found an unexpected blank line in imports
OIPA/task_queue/tasks.py:3:1: F401 'json' imported but unused
OIPA/task_queue/download.py:7:1: F401 'requests' imported but unused
OIPA/task_queue/download.py:142:80: E501 line too long (80 > 79 characters)
OIPA/task_queue/download.py:157:80: E501 line too long (80 > 79 characters)
OIPA/iati_synchroniser/dataset_syncer.py:16:1: F401 'task_queue.tasks.DatasetValidationTask' imported but unused
`

This PR aims to fix those errors.

This PR can be merged when reviewed.