### PR TITLE
Add commitlint to iati.cloud (gb-66)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+-   repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
+    rev: v2.2.0
+    hooks:
+        -   id: commitlint
+            stages: [commit-msg]
+            additional_dependencies: ['@commitlint/config-conventional']

--- a/OIPA/requirements.txt
+++ b/OIPA/requirements.txt
@@ -175,3 +175,4 @@ flower
 django-two-factor-auth==1.12.1
 phonenumbers==8.12.9
 
+pre-commit==2.10.1

--- a/README.MD
+++ b/README.MD
@@ -39,17 +39,18 @@ If you do not have Docker:
 2. Run `virtualenv <name> -p python3` to create a virtual environment
 3. Run `source env/bin/activate` to activate the virtual environment
 4. Install required libraries using `pip install -r requirements.txt`
-5. Create a PostgreSQL database
-6. Set your database credentials in `OIPA/.env` file as follows:
+5. Run `pre-commit install --hook-type commit-msg`
+6. Create a PostgreSQL database
+7. Set your database credentials in `OIPA/.env` file as follows:
     - OIPA_DB_NAME= `your_database_name`
     - OIPA_DB_USER= `your_db_user`
     - OIPA_DB_PASSWORD= `your_db_password`
-7. Run database migrations with `python manage.py migrate`
-8. Start the development server: `python manage.py runserver`
-9. In order for the parser to work, you need to start Redis too: `redis-server`
-10. Create a superuser account: `python manage.py createsuperuser`
-11. Start the process control centre (Supervisor): `python manage.py supervisor`
-12. Open your browser at <a href="http://localhost:8000" target="_blank">localhost:8000</a>
+8. Run database migrations with `python manage.py migrate`
+9. Start the development server: `python manage.py runserver`
+10. In order for the parser to work, you need to start Redis too: `redis-server`
+11. Create a superuser account: `python manage.py createsuperuser`
+12. Start the process control centre (Supervisor): `python manage.py supervisor`
+13. Open your browser at <a href="http://localhost:8000" target="_blank">localhost:8000</a>
 
 ## Full Documentation
 

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['@commitlint/config-conventional']
+};


### PR DESCRIPTION
Added pre-commit with a hook to commitlint, using config-conventional as is done in all front-end projects.

note: 
If this is merged (maybe we should merge this to master instead of develop), everyone using iati.cloud needs to re-install requirements (or just `pip install pre-commit`), and then run `pre-commit install --hook-type commit-msg` as documented in the updated README.
I'll send out a message in the appropriate channel when it is merged.