### PR TITLE
fix: enable retrieving default currency when transaction currency is not specified

### DIFF
--- a/OIPA/iati/parser/IATI_2_02.py
+++ b/OIPA/iati/parser/IATI_2_02.py
@@ -2441,8 +2441,9 @@ class Parse(IatiParser):
                 element.attrib.get('value-date'))
 
         # we don't want to farm out activity level elements/values to
-        # transaction.
-        # currency = self._get_currency_or_raise('transaction/value', currency)
+        # transaction. However, we need to select the default currency if no
+        # currency is added to the value field by the data manager.
+        currency = self._get_currency_or_raise('transaction/value', currency)
 
         transaction = self.get_model('Transaction')
         transaction.value_string = value

--- a/OIPA/iati/parser/IATI_2_03.py
+++ b/OIPA/iati/parser/IATI_2_03.py
@@ -2534,8 +2534,9 @@ class Parse(IatiParser):
                 element.attrib.get('value-date'))
 
         # we don't want to farm out activity level elements/value to
-        # transaction
-        # currency = self._get_currency_or_raise('transaction/value', currency)
+        # transaction.  However, we need to select the default currency if no
+        # currency is added to the value field by the data manager.
+        currency = self._get_currency_or_raise('transaction/value', currency)
 
         transaction = self.get_model('Transaction')
         transaction.value_string = value


### PR DESCRIPTION
will require reparse/reindex. 

Fixes #2592 


A transaction does not have its own "default currency". As stated on the IATI Standard:
"Note: A Currency code should only be declared if different to @default-currency in the iati-activity element."
So it'd make total sense to use the default currency in the parser if and only if there is no currency tag to the value.

original change by @luminhan in commit 3aadba011 reverted here based on the above reasoning, and based on the reported issue.